### PR TITLE
Base64 img source

### DIFF
--- a/sanitizer/index.js
+++ b/sanitizer/index.js
@@ -2,7 +2,7 @@ import xss from 'xss';
 import cssfilter from 'cssfilter';
 
 function isBase64 (value) {
-  const test = /^data:image.+;base64,/;
+  const test = /^data:.+;base64,/;
   return !!value.match(test);
 }
 

--- a/sanitizer/sanitizer.js
+++ b/sanitizer/sanitizer.js
@@ -1640,7 +1640,7 @@ var lib_1$1 = lib$1.xss;
 var lib_2$1 = lib$1.FilterXSS;
 
 function isBase64 (value) {
-  const test = /^data:image.+;base64,/;
+  const test = /^data:.+;base64,/;
   return !!value.match(test);
 }
 

--- a/test/application/sanitizer/sanitizer.spec.js
+++ b/test/application/sanitizer/sanitizer.spec.js
@@ -78,12 +78,20 @@ describe('sanitizer test suite', function () {
       expect(sanitize((html))).toBe(expectedOutput);
     });
 
-    it('valid base64 encoding from an image src attribute', function () {
+    it('valid base64 image png encoding from an image src attribute', function () {
       const html = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot" />';
 
       const expectedOutput = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot" />';
 
       expect(sanitize((html))).toBe(expectedOutput);
+    });
+
+    it('valid base64 octet-stream encoding from an image src attribute', function () {
+        const html = '<img src="data:application/octet-stream;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg==" alt="Blue square" />';
+
+        const expectedOutput = '<img src="data:application/octet-stream;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg==" alt="Blue square" />';
+
+        expect(sanitize((html))).toBe(expectedOutput);
     });
   });
 });

--- a/test/application/selectors/certificate.spec.js
+++ b/test/application/selectors/certificate.spec.js
@@ -80,7 +80,7 @@ describe('certificate selectors test suite', function () {
       store.dispatch(updateCertificateDefinition(v2Fixture));
       const state = store.getState();
 
-      expect(getIssueDate(state)).toBe('Jan 23, 2018');
+      expect(getIssueDate(state)).toBe('Jan 22, 2018');
     });
   });
 


### PR DESCRIPTION
Allows different types of base64 encodings to be part of an `img src=` reference. Added an example for octet-stream images to show. I tested this on my local machine, curious if @lemoustachiste has any hesitations for allowing multiple source types that aren't explicitly images. In another example (PR incoming), it allows for an embedded PDF to be downloaded through an `a href=` link. 

Also there was a problem with a test, not sure if there was a date format/timezone problem on my machine, but it needed to be Jan 22 instead of 23. 