### PR TITLE
Add fullscreen fallback for lack of displayHTML property

### DIFF
--- a/src/components/organisms/FullCertificate/FullCertificate.js
+++ b/src/components/organisms/FullCertificate/FullCertificate.js
@@ -7,7 +7,7 @@ import '../../atoms/VerifyButton';
 import '../../atoms/FinalVerificationStep';
 
 function renderDisplayHTML (displayHTML) {
-  return html`<section class='buv-c-full-certificate'>${unsafeHTML(displayHTML)}</section>`;
+  return html`<section class='buv-c-full-certificate qa-full-certificate'>${unsafeHTML(displayHTML)}</section>`;
 }
 
 export default function FullCertificate ({

--- a/src/components/organisms/FullScreenCertificate/FullScreenCertificate.js
+++ b/src/components/organisms/FullScreenCertificate/FullScreenCertificate.js
@@ -7,9 +7,14 @@ import '../../atoms/DownloadLink';
 import '../../atoms/FinalVerificationStep';
 import '../../atoms/VerifyOtherCertificateLink';
 import BlockcertsLogo from '../../atoms/BlockcertsLogo';
+import '../../atoms/VerifyButton';
+import '../../atoms/FullCertificateV1';
 import '../../molecules/Metadata';
 import '../../molecules/SocialShare';
-import '../../atoms/VerifyButton';
+
+function renderDisplayHTML (displayHTML) {
+  return html`<div class='buv-c-fullscreen-certificate__certificate  qa-fullscreen-certificate'>${unsafeHTML(displayHTML)}</div>`;
+}
 
 export default function FullScreenCertificate ({
   hasCertificateDefinition,
@@ -18,10 +23,6 @@ export default function FullScreenCertificate ({
   onClose
 }) {
   if (!hasCertificateDefinition) {
-    return null;
-  }
-
-  if (!displayHTML) {
     return null;
   }
 
@@ -47,7 +48,7 @@ export default function FullScreenCertificate ({
           <buv-verify-other-certificate class='buv-c-fullscreen-certificate__verify-other'></buv-verify-other-certificate>
         </div>
         <div class='buv-c-fullscreen-certificate__certificate'>
-          ${unsafeHTML(displayHTML)}
+          ${displayHTML ? renderDisplayHTML(displayHTML) : html`<buv-full-certificate-v1></buv-full-certificate-v1>`}
         </div>
       </section>
     </section>

--- a/test/application/components/organisms/FullCertificate.spec.js
+++ b/test/application/components/organisms/FullCertificate.spec.js
@@ -1,19 +1,26 @@
-import FullScreenCertificate from '../../../../src/components/organisms/FullScreenCertificate/FullScreenCertificate';
+import FullCertificate from '../../../../src/components/organisms/FullCertificate/FullCertificate';
 import { assertClassInStringBits } from '../helpers/assertClass';
 
-describe('FullScreenCertificate component test suite', function () {
+describe('FullCertificate component test suite', function () {
+  describe('given there is not certificate definition', function () {
+    it('should return null', function () {
+      const instance = FullCertificate({ hasCertificateDefinition: false });
+      expect(instance).toBeNull();
+    });
+  });
+
   describe('given the certificate has a displayHTML property', function () {
     it('should render the displayHTML property', function () {
       const fixtureDisplayHTML = '<div>This is a test</div>';
-      const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
+      const instance = FullCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
       // ideally we would test that the displayHTML is rendered, but lit does not return the unsafeHTML result
-      expect(assertClassInStringBits(instance, 'qa-fullscreen-certificate')).toBe(true);
+      expect(assertClassInStringBits(instance, 'qa-full-certificate')).toBe(true);
     });
   });
 
   describe('given the certificate does not have a displayHTML property', function () {
     it('should render the certificate as v1', function () {
-      const instance = FullScreenCertificate({ hasCertificateDefinition: true });
+      const instance = FullCertificate({ hasCertificateDefinition: true });
       const instanceAsString = JSON.stringify(instance);
       expect(instanceAsString).toContain('buv-full-certificate-v1');
     });

--- a/test/application/components/organisms/FullScreenCertificate.spec.js
+++ b/test/application/components/organisms/FullScreenCertificate.spec.js
@@ -1,0 +1,28 @@
+import FullScreenCertificate from '../../../../src/components/organisms/FullScreenCertificate/FullScreenCertificate';
+import { assertClassInStringBits } from '../helpers/assertClass';
+
+describe('FullScreenCertificate component test suite', function () {
+  describe('given there is not certificate definition', function () {
+    it('should return null', function () {
+      const instance = FullScreenCertificate({ hasCertificateDefinition: false });
+      expect(instance).toBeNull();
+    });
+  });
+
+  describe('given the certificate has a displayHTML property', function () {
+    it('should render the displayHTML property', function () {
+      const fixtureDisplayHTML = '<div>This is a test</div>';
+      const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
+      // ideally we would test that the displayHTML is rendered, but lit does not return the unsafeHTML result
+      expect(assertClassInStringBits(instance, 'qa-fullscreen-certificate')).toBe(true);
+    });
+  });
+
+  describe('given the certificate does not have a displayHTML property', function () {
+    it('should render the certificate as v1', function () {
+      const instance = FullScreenCertificate({ hasCertificateDefinition: true });
+      const instanceAsString = JSON.stringify(instance);
+      expect(instanceAsString).toContain('buv-full-certificate-v1');
+    });
+  });
+});

--- a/test/application/components/organisms/FullScreenCertificate.test.js
+++ b/test/application/components/organisms/FullScreenCertificate.test.js
@@ -1,0 +1,21 @@
+import FullScreenCertificate from '../../../../src/components/organisms/FullScreenCertificate/FullScreenCertificate';
+import { assertClassInStringBits } from '../helpers/assertClass';
+
+describe('FullScreenCertificate component test suite', function () {
+  describe('given the certificate has a displayHTML property', function () {
+    it('should render the displayHTML property', function () {
+      const fixtureDisplayHTML = '<div>This is a test</div>';
+      const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
+      // ideally we would test that the displayHTML is rendered, but lit does not return the unsafeHTML result
+      expect(assertClassInStringBits(instance, 'qa-fullscreen-certificate')).toBe(true);
+    });
+  });
+
+  describe('given the certificate does not have a displayHTML property', function () {
+    it('should render the certificate as v1', function () {
+      const instance = FullScreenCertificate({ hasCertificateDefinition: true });
+      const instanceAsString = JSON.stringify(instance);
+      expect(instanceAsString).toContain('buv-full-certificate-v1');
+    });
+  });
+});


### PR DESCRIPTION
avoid breakage in fullscreen mode and render as good as possible without a `displayHTML` property