### PR TITLE
Prevent multiple renders of blockcerts' display after state update

### DIFF
--- a/src/components/organisms/FullCertificate/FullCertificate.ts
+++ b/src/components/organisms/FullCertificate/FullCertificate.ts
@@ -9,6 +9,7 @@ import '../../atoms/FinalVerificationStep';
 import getText from '../../../i18n/getText';
 import urlToLink from '../../../helpers/urlToLink';
 import domain from '../../../domain';
+import { IFullScreenCertificateAPI } from '../FullScreenCertificate/FullScreenCertificate';
 
 function renderDisplayHTML (displayHTML: string, clickableUrls: boolean): TemplateResult {
   const buvCertificateClasses: string[] = [
@@ -36,6 +37,14 @@ export class FullCertificateComponent extends LitElement {
       hasCertificateDefinition: Boolean,
       displayHTML: String
     };
+  }
+
+  _shouldRender (
+    _props: IFullScreenCertificateAPI,
+    _changedProps: IFullScreenCertificateAPI,
+    _prevProps: IFullScreenCertificateAPI
+  ): boolean {
+    return !!_changedProps?.displayHTML;
   }
 
   _render ({

--- a/src/components/organisms/FullCertificate/FullCertificate.ts
+++ b/src/components/organisms/FullCertificate/FullCertificate.ts
@@ -1,4 +1,4 @@
-import { html } from '@polymer/lit-element';
+import { html, LitElement } from '@polymer/lit-element';
 import { TemplateResult } from 'lit-html';
 import { unsafeHTML } from 'lit-html/lib/unsafe-html.js';
 import CSS from './_components.full-certificate-css';
@@ -25,20 +25,29 @@ function renderDisplayHTML (displayHTML: string, clickableUrls: boolean): Templa
 
 export interface IFullCertificate {
   clickableUrls?: boolean;
-  hasCertificateDefinition: boolean;
+  hasCertificateDefinition?: boolean;
   displayHTML?: string;
 }
 
-export default function FullCertificate ({
-  clickableUrls,
-  hasCertificateDefinition,
-  displayHTML
-}: IFullCertificate): TemplateResult {
-  if (!hasCertificateDefinition) {
-    return null;
+export class FullCertificateComponent extends LitElement {
+  static get properties () {
+    return {
+      clickableUrls: Boolean,
+      hasCertificateDefinition: Boolean,
+      displayHTML: String
+    };
   }
 
-  return html`
+  _render ({
+    clickableUrls,
+    hasCertificateDefinition,
+    displayHTML
+  }: IFullCertificate): TemplateResult {
+    if (!hasCertificateDefinition) {
+      return null;
+    }
+
+    return html`
     ${CSS}
     ${displayHTML ? renderDisplayHTML(displayHTML, clickableUrls) : html`<buv-full-certificate-v1></buv-full-certificate-v1>`}
     <div class='buv-c-full-certificate__details'>
@@ -48,4 +57,19 @@ export default function FullCertificate ({
       </buv-final-verification-step>
     </div>
   `;
+  }
 }
+
+window.customElements.define('buv-full-certificate-raw', FullCertificateComponent);
+function FullCertificateWrapper (props: IFullCertificate) {
+  return html`
+    <buv-full-certificate-raw
+      clickableUrls = '${props.clickableUrls}'
+      hasCertificateDefinition = '${props.hasCertificateDefinition}'
+      displayHTML = '${props.displayHTML}'
+    ></buv-full-certificate-raw>`;
+}
+
+export {
+  FullCertificateWrapper as FullCertificate
+};

--- a/src/components/organisms/FullCertificate/FullCertificateContainer.ts
+++ b/src/components/organisms/FullCertificate/FullCertificateContainer.ts
@@ -1,5 +1,5 @@
 import connector from '../../../store/connector';
-import FullCertificate, { IFullCertificate } from './FullCertificate';
+import { FullCertificate, IFullCertificate } from './FullCertificate';
 import {
   getCertificateDefinition,
   getDisplayAsHTML

--- a/src/components/organisms/FullScreenCertificate/FullScreenCertificate.ts
+++ b/src/components/organisms/FullScreenCertificate/FullScreenCertificate.ts
@@ -1,4 +1,4 @@
-import { html } from '@polymer/lit-element';
+import { html, LitElement } from '@polymer/lit-element';
 import { TemplateResult } from 'lit-html';
 import { unsafeHTML } from 'lit-html/lib/unsafe-html.js';
 import CSS from './_components.fullscreen-certificate-css';
@@ -24,59 +24,89 @@ function renderDisplayHTML (displayHTML: string, clickableUrls: boolean): Templa
 
 export interface IFullScreenCertificateAPI {
   clickableUrls?: boolean;
-  hasCertificateDefinition: boolean;
+  hasCertificateDefinition?: boolean;
   recipientName?: string;
   displayHTML?: string;
   onClose?: () => any;
   disableDownloadPdf?: boolean;
 }
 
-export default function FullScreenCertificate ({
-  clickableUrls,
-  hasCertificateDefinition,
-  recipientName,
-  displayHTML,
-  onClose,
-  disableDownloadPdf
-}: IFullScreenCertificateAPI): TemplateResult {
-  if (!hasCertificateDefinition) {
-    return null;
+export class FullScreenCertificateComponent extends LitElement {
+  static get properties () {
+    return {
+      clickableUrls: Boolean,
+      hasCertificateDefinition: Boolean,
+      recipientName: String,
+      displayHTML: String,
+      onClose: Function,
+      disableDownloadPdf: Boolean
+    };
   }
 
-  const buvFullscreenCertificateClasses: string[] = [
-    'buv-c-fullscreen-certificate__certificate',
-    'qa-fullscreen-certificate'
-  ];
-  if (displayHTML && domain.certificates.displayHtmlHasNoWidthConstraint(displayHTML)) {
-    buvFullscreenCertificateClasses.push('buv-c-certificate--fixed-width');
-  }
+  _render ({
+    clickableUrls,
+    hasCertificateDefinition,
+    recipientName,
+    displayHTML,
+    onClose,
+    disableDownloadPdf
+  }: IFullScreenCertificateAPI): TemplateResult {
+    if (!hasCertificateDefinition) {
+      return null;
+    }
 
-  return html`
-    ${CSS}
-    <section class='buv-c-fullscreen-certificate'>
-      <header class='buv-c-fullscreen-certificate-header'>
-        <div class='buv-c-fullscreen-certificate-header__content'>
-          <h1 class='buv-c-fullscreen-certificate__title'>${recipientName}</h1>
-          ${CloseButton({ onClick: onClose, className: 'buv-c-fullscreen-certificate__close' })}
-        </div>  
-      </header>
-      <section class='buv-c-fullscreen-certificate__content'>
-        <div class='buv-c-fullscreen-certificate__details'>
-          <buv-final-verification-step class='buv-c-fullscreen-certificate__verification-status' isVisible hideLink standalone>
-            <buv-verify-button type='link'>${getText('text.verifyAgain')}</buv-verify-button>
-          </buv-final-verification-step>
-          <buv-certificate-details direction='column' hideRecipientName></buv-certificate-details>
-          <buv-metadata class='buv-c-fullscreen-certificate__details-item  buv-c-fullscreen-certificate__separator' display='plaintext'></buv-metadata>
-          ${disableDownloadPdf ? '' : html`<buv-download-pdf-link class='buv-c-fullscreen-certificate__details-item' display='plaintext'></buv-download-pdf-link>`}
-          <buv-download-link class='buv-c-fullscreen-certificate__details-item' display='plaintext'></buv-download-link>
-          <buv-social-share class='buv-c-fullscreen-certificate__details-item' display='plaintext'></buv-social-share>
-          ${BlockcertsLogo({ className: 'buv-c-fullscreen-certificate__separator', showMotto: true })}
-          <buv-verify-other-certificate class='buv-c-fullscreen-certificate__verify-other'></buv-verify-other-certificate>
-        </div>
-        <div class$=${buvFullscreenCertificateClasses.join(' ')}>
-          ${displayHTML ? renderDisplayHTML(displayHTML, clickableUrls) : html`<buv-full-certificate-v1></buv-full-certificate-v1>`}
-        </div>
+    const buvFullscreenCertificateClasses: string[] = [
+      'buv-c-fullscreen-certificate__certificate',
+      'qa-fullscreen-certificate'
+    ];
+    if (displayHTML && domain.certificates.displayHtmlHasNoWidthConstraint(displayHTML)) {
+      buvFullscreenCertificateClasses.push('buv-c-certificate--fixed-width');
+    }
+
+    return html`
+      ${CSS}
+      <section class='buv-c-fullscreen-certificate'>
+        <header class='buv-c-fullscreen-certificate-header'>
+          <div class='buv-c-fullscreen-certificate-header__content'>
+            <h1 class='buv-c-fullscreen-certificate__title'>${recipientName}</h1>
+            ${CloseButton({ onClick: onClose, className: 'buv-c-fullscreen-certificate__close' })}
+          </div>  
+        </header>
+        <section class='buv-c-fullscreen-certificate__content'>
+          <div class='buv-c-fullscreen-certificate__details'>
+            <buv-final-verification-step class='buv-c-fullscreen-certificate__verification-status' isVisible hideLink standalone>
+              <buv-verify-button type='link'>${getText('text.verifyAgain')}</buv-verify-button>
+            </buv-final-verification-step>
+            <buv-certificate-details direction='column' hideRecipientName></buv-certificate-details>
+            <buv-metadata class='buv-c-fullscreen-certificate__details-item  buv-c-fullscreen-certificate__separator' display='plaintext'></buv-metadata>
+            ${disableDownloadPdf ? '' : html`<buv-download-pdf-link class='buv-c-fullscreen-certificate__details-item' display='plaintext'></buv-download-pdf-link>`}
+            <buv-download-link class='buv-c-fullscreen-certificate__details-item' display='plaintext'></buv-download-link>
+            <buv-social-share class='buv-c-fullscreen-certificate__details-item' display='plaintext'></buv-social-share>
+            ${BlockcertsLogo({ className: 'buv-c-fullscreen-certificate__separator', showMotto: true })}
+            <buv-verify-other-certificate class='buv-c-fullscreen-certificate__verify-other'></buv-verify-other-certificate>
+          </div>
+          <div class$=${buvFullscreenCertificateClasses.join(' ')}>
+            ${displayHTML ? renderDisplayHTML(displayHTML, clickableUrls) : html`<buv-full-certificate-v1></buv-full-certificate-v1>`}
+          </div>
+        </section>
       </section>
-    </section>
-  `;
+    `;
+  }
 }
+
+window.customElements.define('buv-fullscreen-certificate-raw', FullScreenCertificateComponent);
+function FullScreenCertificateWrapper (props: IFullScreenCertificateAPI) {
+  return html`
+    <buv-fullscreen-certificate-raw
+      clickableUrls = '${props.clickableUrls}'
+      hasCertificateDefinition = '${props.hasCertificateDefinition}'
+      recipientName = '${props.recipientName}'
+      displayHTML = '${props.displayHTML}'
+      onClose = '${props.onClose}'
+      disableDownloadPdf = '${props.disableDownloadPdf}'
+    ></buv-fullscreen-certificate-raw>`;
+}
+
+export {
+  FullScreenCertificateWrapper as FullScreenCertificate
+};

--- a/src/components/organisms/FullScreenCertificate/FullScreenCertificate.ts
+++ b/src/components/organisms/FullScreenCertificate/FullScreenCertificate.ts
@@ -43,6 +43,14 @@ export class FullScreenCertificateComponent extends LitElement {
     };
   }
 
+  _shouldRender (
+    _props: IFullScreenCertificateAPI,
+    _changedProps: IFullScreenCertificateAPI,
+    _prevProps: IFullScreenCertificateAPI
+  ): boolean {
+    return !!_changedProps?.displayHTML;
+  }
+
   _render ({
     clickableUrls,
     hasCertificateDefinition,

--- a/src/components/organisms/FullScreenCertificate/FullScreenCertificateContainer.ts
+++ b/src/components/organisms/FullScreenCertificate/FullScreenCertificateContainer.ts
@@ -1,5 +1,5 @@
 import connector from '../../../store/connector';
-import FullScreenCertificate, { IFullScreenCertificateAPI } from './FullScreenCertificate';
+import { FullScreenCertificate, IFullScreenCertificateAPI } from './FullScreenCertificate';
 import {
   getCertificateDefinition,
   getDisplayAsHTML,

--- a/test/application/components/organisms/FullCertificate.spec.ts
+++ b/test/application/components/organisms/FullCertificate.spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import * as litUnsafeHTML from 'lit-html/lib/unsafe-html.js';
 import { FullCertificateComponent, FullCertificate } from '../../../../src/components/organisms/FullCertificate/FullCertificate';
-import { assertClassInStringBits, assertStringInValues } from '../helpers/assertStringValues';
+import { assertStringInValues } from '../helpers/assertStringValues';
 
 describe('FullCertificate wrapper function test suite', function () {
   describe('setting the attributes of the API to the webcomponent', function () {
@@ -94,6 +94,34 @@ describe('FullCertificate component test suite', function () {
         const result = instance._render({ hasCertificateDefinition: true });
         const instanceAsString = JSON.stringify(result);
         expect(instanceAsString).toContain('buv-full-certificate-v1');
+      });
+    });
+  });
+
+  describe('_shouldRender method', function () {
+    let instance;
+
+    beforeEach(function () {
+      instance = new FullCertificateComponent();
+    });
+
+    afterEach(function () {
+      instance = null;
+    });
+
+    describe('given the displayHTML property is set in the changedProperties object', function () {
+      it('should return true', function () {
+        const result = instance._shouldRender(null, {
+          displayHTML: '<div>Yo</div>'
+        }, null);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('given the displayHTML property is not set in the changedProperties object', function () {
+      it('should return false', function () {
+        const result = instance._shouldRender(null, null, null);
+        expect(result).toBe(false);
       });
     });
   });

--- a/test/application/components/organisms/FullCertificate.spec.ts
+++ b/test/application/components/organisms/FullCertificate.spec.ts
@@ -1,72 +1,100 @@
-import * as litUnsafeHTML from 'lit-html/lib/unsafe-html.js';
 import sinon from 'sinon';
-import FullCertificate from '../../../../src/components/organisms/FullCertificate/FullCertificate';
-import { assertStringInValues } from '../helpers/assertStringValues';
+import * as litUnsafeHTML from 'lit-html/lib/unsafe-html.js';
+import { FullCertificateComponent, FullCertificate } from '../../../../src/components/organisms/FullCertificate/FullCertificate';
+import { assertClassInStringBits, assertStringInValues } from '../helpers/assertStringValues';
 
-describe('FullCertificate component test suite', function () {
-  describe('given there is no certificate definition', function () {
-    it('should return null', function () {
-      const instance = FullCertificate({ hasCertificateDefinition: false });
-      expect(instance).toBeNull();
+describe('FullCertificate wrapper function test suite', function () {
+  describe('setting the attributes of the API to the webcomponent', function () {
+    it('- clickableUrls', function () {
+      const instance = FullCertificate({});
+      expect(instance.strings[0].includes('clickableUrls')).toBe(true);
+    });
+
+    it('- hasCertificateDefinition', function () {
+      const instance = FullCertificate({});
+      expect(instance.strings[1].includes('hasCertificateDefinition')).toBe(true);
+    });
+
+    it('- displayHTML', function () {
+      const instance = FullCertificate({});
+      expect(instance.strings[2].includes('displayHTML')).toBe(true);
     });
   });
 
-  describe('given the certificate has a displayHTML property', function () {
-    beforeEach(function () {
-      // call through unsafeHTML directive
-      sinon.stub(litUnsafeHTML, 'unsafeHTML').callsFake(str => str);
+  describe('passing the API values to the webcomponent', function () {
+    it('- clickableUrls', function () {
+      const instance = FullCertificate({ clickableUrls: true });
+      expect(instance.values[0]).toBe(true);
     });
 
-    afterEach(function () {
-      sinon.restore();
-    });
-
-    it('should render the displayHTML property', function () {
-      const fixtureDisplayHTML = '<div>This is a test</div>';
-      const instance = FullCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
-      expect(assertStringInValues(instance, fixtureDisplayHTML)).toBe(true);
-    });
-
-    describe('given the displayHtml is legacy', function () {
-      it('should render the displayHtml inside a parent with a width constrain CSS class', function () {
-        const fixtureDisplayHTML = '<section class="text">This is a test</section>';
-        const instance = FullCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
-        expect(assertStringInValues(instance, 'buv-c-certificate--fixed-width')).toBe(true);
-      });
-    });
-
-    describe('given the displayHtml is not legacy', function () {
-      it('should render the displayHtml inside a parent without a width constrain CSS class', function () {
-        const fixtureDisplayHTML = '<div>This is a test</div>';
-        const instance = FullCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
-        expect(assertStringInValues(instance, 'buv-c-certificate--fixed-width')).toBe(false);
-      });
-    });
-
-    describe('and the displayHTML property contains a URL', function () {
-      describe('and the clickableUrls flag is set to true', function () {
-        it('should transform it to a clickable link', function () {
-          const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
-          const instance = FullCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: true });
-          expect(assertStringInValues(instance, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(true);
-        });
-      });
-
-      describe('and the clickableUrls flag is set to false', function () {
-        it('should not transform it to a clickable link', function () {
-          const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
-          const instance = FullCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: false });
-          expect(assertStringInValues(instance, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(false);
-        });
-      });
-    });
-  });
-
-  describe('given the certificate does not have a displayHTML property', function () {
-    it('should render the certificate as v1', function () {
+    it('- hasCertificateDefinition', function () {
       const instance = FullCertificate({ hasCertificateDefinition: true });
-      const instanceAsString = JSON.stringify(instance);
-      expect(instanceAsString).toContain('buv-full-certificate-v1');
+      expect(instance.values[1]).toBe(true);
+    });
+
+    it('- displayHTML', function () {
+      const fixtureHtml = '<div>Yo</div>';
+      const instance = FullCertificate({ displayHTML: fixtureHtml });
+      expect(instance.values[2]).toBe(fixtureHtml);
+    });
+  });
+});
+describe('FullCertificate component test suite', function () {
+  describe('_render method', function () {
+    describe('given there is no certificate definition', function () {
+      it('should return null', function () {
+        const instance = new FullCertificateComponent();
+        const result = instance._render({ hasCertificateDefinition: false });
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('given the certificate has a displayHTML property', function () {
+      let instance;
+
+      beforeEach(function () {
+        instance = new FullCertificateComponent();
+        // call through unsafeHTML directive
+        sinon.stub(litUnsafeHTML, 'unsafeHTML').callsFake(str => str);
+      });
+
+      afterEach(function () {
+        instance = null;
+        sinon.restore();
+      });
+
+      it('should render the displayHTML property', function () {
+        const fixtureDisplayHTML = '<div>This is a test</div>';
+        const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
+        expect(assertStringInValues(result, fixtureDisplayHTML)).toBe(true);
+      });
+
+      describe('and the displayHTML property contains a URL', function () {
+        describe('and the clickableUrls flag is set to true', function () {
+          it('should transform it to a clickable link', function () {
+            const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
+            const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: true });
+            expect(assertStringInValues(result, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(true);
+          });
+        });
+
+        describe('and the clickableUrls flag is set to false', function () {
+          it('should not transform it to a clickable link', function () {
+            const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
+            const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: false });
+            expect(assertStringInValues(result, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(false);
+          });
+        });
+      });
+    });
+
+    describe('given the certificate does not have a displayHTML property', function () {
+      it('should render the certificate as v1', function () {
+        const instance = new FullCertificateComponent();
+        const result = instance._render({ hasCertificateDefinition: true });
+        const instanceAsString = JSON.stringify(result);
+        expect(instanceAsString).toContain('buv-full-certificate-v1');
+      });
     });
   });
 });

--- a/test/application/components/organisms/FullScreenCertificate.spec.ts
+++ b/test/application/components/organisms/FullScreenCertificate.spec.ts
@@ -145,4 +145,32 @@ describe('FullScreenCertificate component test suite', function () {
       });
     });
   });
+
+  describe('_shouldRender method', function () {
+    let instance;
+
+    beforeEach(function () {
+      instance = new FullScreenCertificateComponent();
+    });
+
+    afterEach(function () {
+      instance = null;
+    });
+
+    describe('given the displayHTML property is set in the changedProperties object', function () {
+      it('should return true', function () {
+        const result = instance._shouldRender(null, {
+          displayHTML: '<div>Yo</div>'
+        }, null);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('given the displayHTML property is not set in the changedProperties object', function () {
+      it('should return false', function () {
+        const result = instance._shouldRender(null, null, null);
+        expect(result).toBe(false);
+      });
+    });
+  });
 });

--- a/test/application/components/organisms/FullScreenCertificate.spec.ts
+++ b/test/application/components/organisms/FullScreenCertificate.spec.ts
@@ -1,72 +1,148 @@
 import sinon from 'sinon';
 import * as litUnsafeHTML from 'lit-html/lib/unsafe-html.js';
-import FullScreenCertificate from '../../../../src/components/organisms/FullScreenCertificate/FullScreenCertificate';
+import { FullScreenCertificateComponent, FullScreenCertificate } from '../../../../src/components/organisms/FullScreenCertificate/FullScreenCertificate';
 import { assertClassInStringBits, assertStringInValues } from '../helpers/assertStringValues';
 
-describe('FullScreenCertificate component test suite', function () {
-  describe('given there is no certificate definition', function () {
-    it('should return null', function () {
-      const instance = FullScreenCertificate({ hasCertificateDefinition: false });
-      expect(instance).toBeNull();
+describe('FullScreenCertificate wrapper function test suite', function () {
+  describe('setting the attributes of the API to the webcomponent', function () {
+    it('- clickableUrls', function () {
+      const instance = FullScreenCertificate({});
+      expect(instance.strings[0].includes('clickableUrls')).toBe(true);
+    });
+
+    it('- hasCertificateDefinition', function () {
+      const instance = FullScreenCertificate({});
+      expect(instance.strings[1].includes('hasCertificateDefinition')).toBe(true);
+    });
+
+    it('- recipientName', function () {
+      const instance = FullScreenCertificate({});
+      expect(instance.strings[2].includes('recipientName')).toBe(true);
+    });
+
+    it('- displayHTML', function () {
+      const instance = FullScreenCertificate({});
+      expect(instance.strings[3].includes('displayHTML')).toBe(true);
+    });
+
+    it('- onClose', function () {
+      const instance = FullScreenCertificate({});
+      expect(instance.strings[4].includes('onClose')).toBe(true);
+    });
+
+    it('- disableDownloadPdf', function () {
+      const instance = FullScreenCertificate({});
+      expect(instance.strings[5].includes('disableDownloadPdf')).toBe(true);
     });
   });
 
-  describe('given the certificate has a displayHTML property', function () {
-    beforeEach(function () {
-      // call through unsafeHTML directive
-      sinon.stub(litUnsafeHTML, 'unsafeHTML').callsFake(str => str);
+  describe('passing the API values to the webcomponent', function () {
+    it('- clickableUrls', function () {
+      const instance = FullScreenCertificate({ clickableUrls: true });
+      expect(instance.values[0]).toBe(true);
     });
 
-    afterEach(function () {
-      sinon.restore();
-    });
-
-    it('should render the displayHTML property', function () {
-      const fixtureDisplayHTML = '<div>This is a test</div>';
-      const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
-      expect(assertStringInValues(instance, fixtureDisplayHTML)).toBe(true);
-    });
-
-    describe.only('given the displayHtml is legacy', function () {
-      it('should render the displayHtml inside a parent with a width constrain CSS class', function () {
-        const fixtureDisplayHTML = '<section class="text">This is a test</section>';
-        const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
-        expect(assertClassInStringBits(instance, 'buv-c-certificate--fixed-width')).toBe(true);
-      });
-    });
-
-    describe('given the displayHtml is not legacy', function () {
-      it('should render the displayHtml inside a parent without a width constrain CSS class', function () {
-        const fixtureDisplayHTML = '<div>This is a test</div>';
-        const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
-        expect(assertStringInValues(instance, 'buv-c-certificate--fixed-width')).toBe(false);
-      });
-    });
-
-    describe('and the displayHTML property contains a URL', function () {
-      describe('and the clickableUrls flag is set to true', function () {
-        it('should transform it to a clickable link', function () {
-          const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
-          const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: true });
-          expect(assertStringInValues(instance, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(true);
-        });
-      });
-
-      describe('and the clickableUrls flag is set to false', function () {
-        it('should not transform it to a clickable link', function () {
-          const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
-          const instance = FullScreenCertificate({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: false });
-          expect(assertStringInValues(instance, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(false);
-        });
-      });
-    });
-  });
-
-  describe('given the certificate does not have a displayHTML property', function () {
-    it('should render the certificate as v1', function () {
+    it('- hasCertificateDefinition', function () {
       const instance = FullScreenCertificate({ hasCertificateDefinition: true });
-      const instanceAsString = JSON.stringify(instance);
-      expect(instanceAsString).toContain('buv-full-certificate-v1');
+      expect(instance.values[1]).toBe(true);
+    });
+
+    it('- recipientName', function () {
+      const fixtureName = 'Jean Jacques';
+      const instance = FullScreenCertificate({ recipientName: fixtureName });
+      expect(instance.values[2]).toBe(fixtureName);
+    });
+
+    it('- displayHTML', function () {
+      const fixtureHtml = '<div>Yo</div>';
+      const instance = FullScreenCertificate({ displayHTML: fixtureHtml });
+      expect(instance.values[3]).toBe(fixtureHtml);
+    });
+
+    it('- onClose', function () {
+      const fixtureOnClose = () => true;
+      const instance = FullScreenCertificate({ onClose: fixtureOnClose });
+      expect(instance.values[4]).toEqual(fixtureOnClose);
+    });
+
+    it('- disableDownloadPdf', function () {
+      const instance = FullScreenCertificate({ disableDownloadPdf: true });
+      expect(instance.values[5]).toBe(true);
+    });
+  });
+});
+describe('FullScreenCertificate component test suite', function () {
+  describe('_render method', function () {
+    describe('given there is no certificate definition', function () {
+      it('should return null', function () {
+        const instance = new FullScreenCertificateComponent();
+        const result = instance._render({ hasCertificateDefinition: false });
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('given the certificate has a displayHTML property', function () {
+      let instance;
+
+      beforeEach(function () {
+        instance = new FullScreenCertificateComponent();
+        // call through unsafeHTML directive
+        sinon.stub(litUnsafeHTML, 'unsafeHTML').callsFake(str => str);
+      });
+
+      afterEach(function () {
+        instance = null;
+        sinon.restore();
+      });
+
+      it('should render the displayHTML property', function () {
+        const fixtureDisplayHTML = '<div>This is a test</div>';
+        const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
+        expect(assertStringInValues(result, fixtureDisplayHTML)).toBe(true);
+      });
+
+      describe('given the displayHtml is legacy', function () {
+        it('should render the displayHtml inside a parent with a width constrain CSS class', function () {
+          const fixtureDisplayHTML = '<section class="text">This is a test</section>';
+          const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
+          expect(assertClassInStringBits(result, 'buv-c-certificate--fixed-width')).toBe(true);
+        });
+      });
+
+      describe('given the displayHtml is not legacy', function () {
+        it('should render the displayHtml inside a parent without a width constrain CSS class', function () {
+          const fixtureDisplayHTML = '<div>This is a test</div>';
+          const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true });
+          expect(assertStringInValues(result, 'buv-c-certificate--fixed-width')).toBe(false);
+        });
+      });
+
+      describe('and the displayHTML property contains a URL', function () {
+        describe('and the clickableUrls flag is set to true', function () {
+          it('should transform it to a clickable link', function () {
+            const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
+            const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: true });
+            expect(assertStringInValues(result, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(true);
+          });
+        });
+
+        describe('and the clickableUrls flag is set to false', function () {
+          it('should not transform it to a clickable link', function () {
+            const fixtureDisplayHTML = '<div>This is a test, click on www.blockcerts.org</div>';
+            const result = instance._render({ displayHTML: fixtureDisplayHTML, hasCertificateDefinition: true, clickableUrls: false });
+            expect(assertStringInValues(result, '<a href="http://www.blockcerts.org" target="_blank" rel="noopener noreferrer">www.blockcerts.org</a>')).toBe(false);
+          });
+        });
+      });
+    });
+
+    describe('given the certificate does not have a displayHTML property', function () {
+      it('should render the certificate as v1', function () {
+        const instance = new FullScreenCertificateComponent();
+        const result = instance._render({ hasCertificateDefinition: true });
+        const instanceAsString = JSON.stringify(result);
+        expect(instanceAsString).toContain('buv-full-certificate-v1');
+      });
     });
   });
 });

--- a/test/setupJest.js
+++ b/test/setupJest.js
@@ -12,7 +12,7 @@ global.customElements = {
 
 Object.defineProperty(global.self, 'crypto', {
   value: {
-    // use node 15.x
+    // use node 15.x or above
     subtle: crypto.webcrypto.subtle,
     getRandomValues: () => new Uint32Array(10)
   }


### PR DESCRIPTION
Especially visible with PDF rendering.