### PR TITLE
Add container and aspect-ratio properties to CSS white list

### DIFF
--- a/sanitizer/index.js
+++ b/sanitizer/index.js
@@ -36,7 +36,9 @@ const whiteListedCssProperties = {
   'grid-area': true,
   'align-self': true,
   'justify-self': true,
-  span: true
+  span: true,
+  container: true,
+	"aspect-ratio": true,
 };
 
 function modifyWhiteList () {


### PR DESCRIPTION
Adds [Container property](https://developer.mozilla.org/en-US/docs/Web/CSS/container) allowing the use of [Container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) and [Aspect Ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).


Use case:
- Container queries allows to make text responsive based on container size
- Maybe you want certificates to be like a A4 page size, so you will need to set aspect-ratio: 1 / 1.414