### PR TITLE
feat(sanitizer): add z-index and text-wrap-style to CSS whitelist

### DIFF
--- a/sanitizer/index.js
+++ b/sanitizer/index.js
@@ -39,6 +39,8 @@ const whiteListedCssProperties = {
   span: true,
   container: true,
 	"aspect-ratio": true,
+  "text-wrap-style": true,
+	"z-index": true,
 };
 
 function modifyWhiteList () {

--- a/sanitizer/sanitizer.js
+++ b/sanitizer/sanitizer.js
@@ -2531,6 +2531,8 @@ const whiteListedCssProperties = {
   span: true,
   container: true,
 	"aspect-ratio": true,
+  "text-wrap-style": true,
+	"z-index": true,
 };
 
 function modifyWhiteList () {


### PR DESCRIPTION
Adds z-index for relative-absolute positioning and [text-wrap-style](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-wrap-style) property for text wrapping.